### PR TITLE
Add redemptions allowed field to offers with promotions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -402,7 +402,6 @@
                                         <input type="hidden" id="offer_mc_id_6" />
                                         <input type="hidden" id="communication_key" />
                                         <input type="hidden" id="communication_key_control" />
-                                        <input type="hidden" id="offer_redemptions" />
                                     </div>
                                 </div>
                             </div>
@@ -415,6 +414,10 @@
                                         <option value="false" selected>No</option>
                                     </select>
                                 </div>
+                            </div>
+                            <div class="slds-form-element" id="redemptions_allowed_form">
+                                <label class="slds-form-element__label" for="text-input-id-1">Redemptions Allowed</label>
+                                <input type="number" class="slds-input" id="offer_redemptions" value="1"/>
                             </div>
                             <div class="slds-box slds-box_xx-small slds-m-vertical_xx-small" id="offer_cell_box">
                                 <h2>Communication History Data - Required for Informational offers</h2>

--- a/public/js/customActivity.js
+++ b/public/js/customActivity.js
@@ -328,7 +328,6 @@ define([
             $("#offer_mc_id_1").val(promoData.mc_id_1);
             $("#offer_mc_id_6").val(promoData.mc_id_6);
             $("#communication_key").val(promoData.communication_cell_id);
-            $("#offer_redemptions").val(promoData.instore_code_1_redemptions);
             $("#offer_campaign_code").val(promoData.campaign_code);
             $("#offer_campaign_name").val(promoData.campaign_name);
             $("#offer_cell_code").val(promoData.cell_code);
@@ -413,13 +412,17 @@ define([
             $("#offer_cell_box").show();
             // hide promotion dropdown
             $("#promotion_element").hide();
+            $("#show_validity_form").hide();
+            $("#redemptions_allowed_form").hide();
             $("#info_button_text_form").show();
 
         } else {
 
             $("#offer_cell_box").hide();
             // show offer promotion
-            $("#promotion_element").show();            
+            $("#promotion_element").show();
+            $("#show_validity_form").show();
+            $("#redemptions_allowed_form").show();
             $("#info_button_text_form").hide();
         }
     }


### PR DESCRIPTION
Redemptions allowed will default to 1, and be settable for both instore and online promotions.  It now ignores the instore_redemptions allowed field from the promo widget, and only uses this input field.